### PR TITLE
fix: add `default` condition to `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "types": "dist/index.d.ts",
     "exports": {
         "require": "./dist/index.js",
-        "import": "./dist/index.mjs"
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
     },
     "keywords": [
         "tailwind",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     ],
     "scripts": {
         "build": "tsup",
+        "prepare": "npm run build",
         "typecheck": "tsc --noEmit",
         "format": "prettier --write ./**/*.{js,jsx,ts,tsx,cjs,json,css,scss}",
         "lint": "eslint src",


### PR DESCRIPTION
Vite 7 requires a `default` condition in the package `exports` map when resolving CSS `@plugin` imports. Without it, the build fails with:

```
Failed to resolve entry for package "tw-bootstrap-grid". The package may have incorrect main/module/exports specified in its package.json.
```

**Changes:**

1. Add `default` to the `exports` field:

```json
"exports": {
    "require": "./dist/index.js",
    "import": "./dist/index.mjs",
    "default": "./dist/index.mjs"
}
```

2. Add a `prepare` script so the package builds correctly when installed directly from GitHub (the `dist/` folder is not committed, so without this script a GitHub install resolves no entry point):

```json
"prepare": "npm run build"
```

No functional changes to the plugin itself.