### PR TITLE
fix: align `main`/`module`/`exports` paths with actual tsup output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
     "version": "1.3.4",
     "type": "module",
     "description": "A Tailwind CSS plugin that adds a responsive, Bootstrap-style grid system.",
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
-        "require": "./dist/index.js",
-        "import": "./dist/index.mjs",
-        "default": "./dist/index.mjs"
+        "require": "./dist/index.cjs",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
     },
     "keywords": [
         "tailwind",


### PR DESCRIPTION
Investigating further into the cause of the issue reported in the PR https://github.com/bawerbozdag/tw-bootstrap-grid/pull/158, I noticed that the real cause is another.

The package declares `"type": "module"`, and `tsup.config.ts` builds with `format: ["esm", "cjs"]`. With `type: module`, tsup produces:

- `dist/index.js` -> ESM
- `dist/index.cjs` -> CJS

However, `package.json` currently references `dist/index.mjs` (which is never generated) and treats `dist/index.js` as CJS. Strict resolvers (e.g. Vite 7 via `@tailwindcss/vite`) fail with:

```
Failed to resolve entry for package "tw-bootstrap-grid". The package may have incorrect main/module/exports specified in its package.json.
```

**Changes:**

```json
"main": "dist/index.cjs",
"module": "dist/index.js",
"exports": {
    "require": "./dist/index.cjs",
    "import": "./dist/index.js",
    "default": "./dist/index.js"
}
```

The `default` condition can be kept as a fallback for resolvers that don't match `import`/`require` explicitly.

No functional changes to the plugin itself.