### PR TITLE
ci: use npm ci in all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,10 @@ jobs:
               with:
                   node-version: 20
                   cache: "npm"
+                  cache-dependency-path: "package-lock.json"
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Run Build
               run: npm run build

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -23,7 +23,7 @@ jobs:
                   cache-dependency-path: "package-lock.json"
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: TypeScript type check
               run: npm run typecheck

--- a/.github/workflows/prettier-format-check.yml
+++ b/.github/workflows/prettier-format-check.yml
@@ -27,7 +27,7 @@ jobs:
                   cache-dependency-path: package-lock.json
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Run Prettier
               run: npm run format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
               with:
                   node-version: 22.14.0
                   registry-url: "https://registry.npmjs.org/"
+                  cache: "npm"
+                  cache-dependency-path: "package-lock.json"
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Build package
               run: npm run build

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -22,11 +22,10 @@ jobs:
               with:
                   node-version: 20
                   cache: "npm"
-                  cache-dependency-path: |
-                      package-lock.json
-                      __tests__/tailwind_v3/package-lock.json
+                  cache-dependency-path: "package-lock.json"
+
             - name: Install all workspace deps
-              run: npm install
+              run: npm ci
 
             - name: Run Build
               run: npm run build
@@ -48,11 +47,10 @@ jobs:
               with:
                   node-version: 20
                   cache: "npm"
-                  cache-dependency-path: |
-                      package-lock.json
-                      __tests__/tailwind_v4/package-lock.json
+                  cache-dependency-path: "package-lock.json"
+
             - name: Install all workspace deps
-              run: npm install
+              run: npm ci
 
             - name: Run Build
               run: npm run build


### PR DESCRIPTION
## What
Switch every GitHub Actions workflow from `npm install` to `npm ci`, and clean up the npm cache configuration that goes along with it:

- `build.yml`, `eslint.yml`, `prettier-format-check.yml`, `release.yml`, `vitest.yml`: replace `npm install` with `npm ci`.
- `release.yml`: add `cache: "npm"` / `cache-dependency-path: "package-lock.json"` to the Node setup step, which previously had no npm cache at all.
- `build.yml`: add `cache-dependency-path: "package-lock.json"` for consistency with the other workflows.
- `vitest.yml`: drop the `__tests__/tailwind_v3/package-lock.json` and `__tests__/tailwind_v4/package-lock.json` entries from `cache-dependency-path` (those lockfiles no longer exist — removed in 182663f) and cache on the root `package-lock.json` only. The test directories are npm workspaces of the root package, so a single root `npm ci` still installs their dependencies.

## Why
`npm install` is free to resolve newer versions inside caret ranges and rewrite `package-lock.json` in place, so the committed lockfile was advisory rather than binding. This mattered most in `release.yml`: the tarball published to npm was built with whatever tsup/typescript versions happened to resolve at that moment, not the versions the lockfile records and CI actually tested against. It also meant CI could flip green or red for reasons invisible in a given diff. `npm ci` installs exactly what's in the lockfile and fails if `package.json` and `package-lock.json` are out of sync, making builds reproducible and tying published artifacts to tested dependency versions.

## What to check
- Confirm the `__tests__/tailwind_v3` and `__tests__/tailwind_v4` directories are indeed npm workspaces of the root `package.json` (so root `npm ci` covers their deps) and don't have their own lockfiles that `npm ci` would now silently ignore.
- Confirm `package-lock.json` is currently in sync with `package.json` in both the root and `demo/` so `npm ci` doesn't start failing workflows that previously passed under `npm install`.
- `release.yml` now caches based on `package-lock.json`; verify that's the correct lockfile for what gets published (no separate lockfile under a publish subdirectory).