### PR TITLE
fix: resolve the plugin factory from the tailwindcss/plugin.js subpath

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -60,3 +60,29 @@ jobs:
             - name: Run tests for tailwind v4
               working-directory: __tests__/tailwind_v4
               run: npm test
+
+    test-dist:
+        name: Run Built Package Tests
+        runs-on: ubuntu-22.04
+
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: "npm"
+                  cache-dependency-path: |
+                      package-lock.json
+                      __tests__/dist_v4/package-lock.json
+            - name: Install all workspace deps
+              run: npm install
+
+            - name: Run Build
+              run: npm run build
+
+            - name: Run tests for the built package
+              working-directory: __tests__/dist_v4
+              run: npm test

--- a/__tests__/dist_v4/index.test.ts
+++ b/__tests__/dist_v4/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "child_process";
+import { createRequire } from "module";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { promisify } from "util";
+import postcss from "postcss";
+import tailwindcss from "@tailwindcss/postcss";
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line
+const tailwind = (tailwindcss as any).default ?? tailwindcss;
+
+/**
+ * Load a snippet in a fresh Node process rooted at this project. Module resolution then
+ * behaves exactly as it does for a consumer, with none of Vite's transforms, aliasing or
+ * dependency pre-bundling in the way. That is the whole point of these tests: they check
+ * that the published artifacts are loadable by Node itself, not that Vite can bundle them.
+ */
+const runInNode = async (type: "module" | "commonjs", source: string): Promise<string> => {
+    const { stdout } = await execFileAsync(process.execPath, [`--input-type=${type}`, "-e", source], {
+        cwd: __dirname,
+    });
+
+    return stdout.trim();
+};
+
+describe("Built package on a Tailwind v4-only install", () => {
+    it("resolves Tailwind v4, not a hoisted v3", async () => {
+        const require = createRequire(resolve(__dirname, "node_modules/tw-bootstrap-grid/"));
+        const { version } = require("tailwindcss/package.json");
+
+        // guards every other test here: if v3 leaked in from the repo root, the artifacts
+        // would load for the wrong reason and the v4 claim would go unverified
+        expect(version).toMatch(/^4\./);
+    });
+
+    it("loads dist/index.js as ESM", async () => {
+        const output = await runInNode(
+            "module",
+            `import plugin from "tw-bootstrap-grid";
+             console.log(typeof plugin, typeof plugin({}).handler);`,
+        );
+
+        expect(output).toBe("function function");
+    });
+
+    it("loads dist/index.cjs as CommonJS", async () => {
+        const output = await runInNode(
+            "commonjs",
+            `const plugin = require("tw-bootstrap-grid");
+             const factory = plugin.default ?? plugin;
+             console.log(typeof factory, typeof factory({}).handler);`,
+        );
+
+        expect(output).toBe("function function");
+    });
+
+    it("generates grid utilities when Tailwind v4 loads the built package", async () => {
+        const result = await postcss([tailwind({ content: [{ raw: "", extension: "html" }] })]).process(
+            `@tailwind utilities;
+                 @plugin "tw-bootstrap-grid";`,
+            { from: resolve(__dirname, "test.css") },
+        );
+
+        expect(result.css).toContain(".row");
+        expect(result.css).toContain(".col-6");
+        expect(result.css).toContain("--bs-gutter-x");
+    });
+});

--- a/__tests__/dist_v4/package.json
+++ b/__tests__/dist_v4/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "tw-bootstrap-grid-test-dist-v4",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "test": "npx vitest run"
+    },
+    "devDependencies": {
+        "@tailwindcss/postcss": "^4.3.3",
+        "tailwindcss": "^4.1.8"
+    }
+}

--- a/__tests__/dist_v4/setup/installBuiltPackage.ts
+++ b/__tests__/dist_v4/setup/installBuiltPackage.ts
@@ -1,0 +1,38 @@
+import { access, cp, mkdir, rm } from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const repoRoot = resolve(__dirname, "../../..");
+const target = resolve(__dirname, "../node_modules/tw-bootstrap-grid");
+
+/**
+ * Copy the built package into this project's node_modules so that it is loaded exactly
+ * the way a consumer loads it: through the published "exports" map, with its bare
+ * "tailwindcss/*" imports resolving against this project's dependencies only.
+ *
+ * A workspace dependency is deliberately not used here. npm would link it, and Node
+ * resolves a symlinked package's imports from the link's realpath, which lands back in
+ * the repo root node_modules where Tailwind v3 is hoisted. Copying keeps the lookup
+ * inside this v4-only project.
+ */
+export const setup = async (): Promise<void> => {
+    const dist = resolve(repoRoot, "dist");
+
+    try {
+        await access(dist);
+    } catch {
+        throw new Error(`No build output at ${dist}. Run "npm run build" in the repo root first.`);
+    }
+
+    await rm(target, { recursive: true, force: true });
+    await mkdir(target, { recursive: true });
+
+    await cp(dist, resolve(target, "dist"), { recursive: true });
+    await cp(resolve(repoRoot, "package.json"), resolve(target, "package.json"));
+};
+
+export const teardown = async (): Promise<void> => {
+    await rm(target, { recursive: true, force: true });
+};

--- a/__tests__/dist_v4/vitest.config.ts
+++ b/__tests__/dist_v4/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: "node",
+        include: ["./index.test.ts"],
+        globalSetup: ["./setup/installBuiltPackage.ts"],
+    },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "workspaces": [
                 "__tests__/tailwind_v3",
-                "__tests__/tailwind_v4"
+                "__tests__/tailwind_v4",
+                "__tests__/dist_v4"
             ],
             "devDependencies": {
                 "@eslint/js": "^9.27.0",
@@ -34,6 +35,20 @@
             "peerDependencies": {
                 "tailwindcss": ">=3.0.0"
             }
+        },
+        "__tests__/dist_v4": {
+            "name": "tw-bootstrap-grid-test-dist-v4",
+            "devDependencies": {
+                "@tailwindcss/postcss": "^4.3.3",
+                "tailwindcss": "^4.1.8"
+            }
+        },
+        "__tests__/dist_v4/node_modules/tailwindcss": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+            "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "__tests__/tailwind_v3": {
             "name": "tw-bootstrap-grid-test-tailwind-v3",
@@ -9799,6 +9814,10 @@
             "peerDependencies": {
                 "tailwindcss": ">=3.0.0"
             }
+        },
+        "node_modules/tw-bootstrap-grid-test-dist-v4": {
+            "resolved": "__tests__/dist_v4",
+            "link": true
         },
         "node_modules/tw-bootstrap-grid-test-tailwind-v3": {
             "resolved": "__tests__/tailwind_v3",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,13 @@
         "lint:fix": "eslint src --fix",
         "test:v3": "cd __tests__/tailwind_v3 && npm install && npm test",
         "test:v4": "cd __tests__/tailwind_v4 && npm install && npm test",
-        "test": "npm run build && npm run test:v3 && npm run test:v4"
+        "test:dist": "cd __tests__/dist_v4 && npm install && npm test",
+        "test": "npm run build && npm run test:v3 && npm run test:v4 && npm run test:dist"
     },
     "workspaces": [
         "__tests__/tailwind_v3",
-        "__tests__/tailwind_v4"
+        "__tests__/tailwind_v4",
+        "__tests__/dist_v4"
     ],
     "peerDependencies": {
         "tailwindcss": ">=3.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import resolveGutters, { type IGridOptions } from "./utils/resolveGutters";
 import type { CSSRuleObject, PluginAPI } from "tailwindcss/types/config";
-import tailwindcss from "tailwindcss";
-
-const plugin = "plugin" in tailwindcss ? tailwindcss.plugin : require("tailwindcss/plugin");
+// the plugin subpath is a JS entry in both v3 and v4, unlike the package root, which v4
+// maps to CSS / its compile API rather than the plugin factory. the ".js" suffix is
+// required: v3 ships no "exports" map, so Node's ESM resolver cannot resolve the
+// extensionless "tailwindcss/plugin" there, while v4 maps "./plugin.js" explicitly
+import plugin from "tailwindcss/plugin.js";
 
 export interface ITwBootstrapGridOptions extends IGridOptions {
     generateContainers?: boolean;


### PR DESCRIPTION
## What

`src/index.ts` now gets the Tailwind plugin factory from a single static import of `tailwindcss/plugin.js`, replacing the previous root-package import plus `"plugin" in tailwindcss ? … : require("tailwindcss/plugin")` fallback.

Alongside the fix, this adds a third test project, `__tests__/dist_v4`, that exercises the **built** package against a Tailwind v4-only install, plus a `test-dist` CI job and a `test:dist` root script wired into `npm test`.

## Why

The old resolution strategy broke for consumers on Tailwind v4:

- Tailwind v4's package root no longer exposes the plugin factory (it maps to CSS / the compile API), so the `"plugin" in tailwindcss` branch was never taken and execution always fell through to `require("tailwindcss/plugin")`.
- `dist/index.js` is native ESM, where `require` does not exist — so the fallback threw at load time instead of producing a plugin.

The `.js` suffix in the new import path is load-bearing in both directions, and the reasoning is captured in a comment at the import site: Tailwind v3 ships no `exports` map, so Node's ESM resolver cannot resolve the extensionless `tailwindcss/plugin` there, while v4's `exports` map lists `./plugin.js` explicitly. The subpath is a JS entry in both majors, so one static import covers v3 and v4 with no runtime branching.

### Why the existing tests didn't catch it

`__tests__/tailwind_v3` and `__tests__/tailwind_v4` consume `tw-bootstrap-grid` as a workspace dependency and run under Vitest. That means npm symlinks the package, Node resolves its imports from the link's realpath back into the hoisted root `node_modules` (where v3 lives), and Vite's transforms/pre-bundling paper over the ESM/CJS boundary. Both effects together hid the failure.

`__tests__/dist_v4` is built to avoid all three:

- A `globalSetup` hook (`setup/installBuiltPackage.ts`) **copies** `dist/` and `package.json` into the project's own `node_modules` rather than linking, keeping module lookup inside a v4-only dependency tree. It fails with a clear message if `dist/` is missing.
- The ESM and CJS load tests run their snippets in a **fresh `node` process** (`--input-type=module` / `commonjs`), so resolution behaves exactly as it does for a real consumer, with no bundler in the path.
- A guard test asserts the resolved Tailwind is `4.x`, so the suite can't pass for the wrong reason if v3 ever leaks in from the root.
- A final test runs the copied package through `@tailwindcss/postcss` via `@plugin "tw-bootstrap-grid"` and checks that `.row`, `.col-6`, and `--bs-gutter-x` are actually emitted.

## Reviewer checklist

- **The load-bearing `.js`**: confirm you agree that `tailwindcss/plugin.js` resolves under both v3 (no `exports` map, physical file) and v4 (`exports` entry). Dropping the extension or adding it back to the root import would silently regress ESM consumers.
- **Copy-instead-of-link in `installBuiltPackage.ts`**: this is the crux of the new test's validity. If it were switched to a workspace dependency, the suite would go back to resolving the hoisted v3 and stop testing anything.
- **`teardown` removes `node_modules/tw-bootstrap-grid`** in the test project — worth a sanity check that a failed run doesn't leave a stale copy that a later run would treat as fresh.
- **CI `cache-dependency-path`** in the new `test-dist` job lists `__tests__/dist_v4/package-lock.json`, but this is a single-root-lockfile workspace and no such file is added here. The root entry still matches so caching works, but confirm `actions/setup-node` doesn't warn or hard-fail on the unresolved path.
- **`npm test` ordering**: `test:dist` is appended after `test:v3`/`test:v4` and depends on the earlier `npm run build` in the same chain. Running `npm run test:dist` standalone on a clean checkout will hit the "No build output" error by design — flag if you'd rather it build implicitly.
- No behavioral change to the generated utilities is intended; the v3/v4 suites should be unchanged and green.