### PR TITLE
refactor(offset): use margin-inline-start instead of [dir="rtl"] override

### DIFF
--- a/__tests__/tailwind_v3/tests/offset.test.ts
+++ b/__tests__/tailwind_v3/tests/offset.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "vitest";
 /* eslint-disable no-unused-vars */
 const testOffset = (runTailwind: (html: string) => Promise<string>) => {
     // we only test .offset-1, .offset-6 and .offset-12 as representative samples.
-    test("generates .offset-{1-12} classes with correct margin-left and RTL overrides", async () => {
+    test("generates .offset-{1-12} classes with correct margin-inline-start", async () => {
         const css = await runTailwind(`
             <div class="offset-1"></div>
             <div class="offset-6"></div>
@@ -12,24 +12,28 @@ const testOffset = (runTailwind: (html: string) => Promise<string>) => {
 
         // .offset-1
         expect(css).toContain(".offset-1");
-        expect(css).toContain("margin-left: 8.333333333333332%");
-        // for RTL
-        expect(css).toContain('[dir="rtl"] .offset-1');
-        expect(css).toContain("margin-right: 8.333333333333332%");
+        expect(css).toContain("margin-inline-start: 8.333333333333332%");
 
         // .offset-6
         expect(css).toContain(".offset-6");
-        expect(css).toContain("margin-left: 50%");
-        // for RTL
-        expect(css).toContain('[dir="rtl"] .offset-6');
-        expect(css).toContain("margin-right: 50%");
+        expect(css).toContain("margin-inline-start: 50%");
 
         // .offset-12
         expect(css).toContain(".offset-12");
-        expect(css).toContain("margin-left: 100%");
-        // for RTL
-        expect(css).toContain('[dir="rtl"] .offset-12');
-        expect(css).toContain("margin-right: 100%");
+        expect(css).toContain("margin-inline-start: 100%");
+    });
+
+    // the logical property flips with the element's own direction, so no
+    // [dir="rtl"] ancestor selector (and no physical margin) is emitted.
+    test("flips offsets via the logical property, including dir on the element itself", async () => {
+        const css = await runTailwind(`
+            <div class="offset-3" dir="rtl"></div>
+        `);
+
+        expect(css).toMatch(/\.offset-3\s*\{\s*margin-inline-start:\s*25%;\s*\}/);
+        expect(css).not.toContain('[dir="rtl"] .offset-3');
+        expect(css).not.toMatch(/\.offset-3\s*\{[^}]*margin-left/);
+        expect(css).not.toMatch(/\.offset-3\s*\{[^}]*margin-right/);
     });
 };
 

--- a/__tests__/tailwind_v4/tests/offset.test.ts
+++ b/__tests__/tailwind_v4/tests/offset.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "vitest";
 /* eslint-disable no-unused-vars */
 const testOffset = (runTailwind: (html: string) => Promise<string>) => {
     // we only test .offset-1, .offset-6 and .offset-12 as representative samples.
-    test("generates .offset-{1-12} classes with correct margin-left and RTL overrides", async () => {
+    test("generates .offset-{1-12} classes with correct margin-inline-start", async () => {
         const css = await runTailwind(`
             <div class="offset-1"></div>
             <div class="offset-6"></div>
@@ -12,21 +12,28 @@ const testOffset = (runTailwind: (html: string) => Promise<string>) => {
 
         // .offset-1
         expect(css).toContain(".offset-1");
-        expect(css).toMatch(
-            /\.offset-1\s*\{\s*margin-left:\s*8\.333.*?\[dir="rtl"\]\s*&\s*\{\s*margin-left:\s*0;\s*margin-right:\s*8\.333.*?\s*\}/s,
-        );
+        expect(css).toMatch(/\.offset-1\s*\{\s*margin-inline-start:\s*8\.333[^;]*;\s*\}/);
 
         // .offset-6
         expect(css).toContain(".offset-6");
-        expect(css).toMatch(
-            /\.offset-6\s*\{\s*margin-left:\s*50%;.*?\[dir="rtl"\]\s*&\s*\{\s*margin-left:\s*0;\s*margin-right:\s*50%;\s*\}/s,
-        );
+        expect(css).toMatch(/\.offset-6\s*\{\s*margin-inline-start:\s*50%;\s*\}/);
 
         // .offset-12
         expect(css).toContain(".offset-12");
-        expect(css).toMatch(
-            /\.offset-12\s*\{\s*margin-left:\s*100%;.*?\[dir="rtl"\]\s*&\s*\{\s*margin-left:\s*0;\s*margin-right:\s*100%;\s*\}/s,
-        );
+        expect(css).toMatch(/\.offset-12\s*\{\s*margin-inline-start:\s*100%;\s*\}/);
+    });
+
+    // the logical property flips with the element's own direction, so no
+    // [dir="rtl"] ancestor selector (and no physical margin) is emitted.
+    test("flips offsets via the logical property, including dir on the element itself", async () => {
+        const css = await runTailwind(`
+            <div class="offset-3" dir="rtl"></div>
+        `);
+
+        expect(css).toMatch(/\.offset-3\s*\{\s*margin-inline-start:\s*25%;\s*\}/);
+        expect(css).not.toContain('[dir="rtl"]');
+        expect(css).not.toMatch(/\.offset-3\s*\{[^}]*margin-left/);
+        expect(css).not.toMatch(/\.offset-3\s*\{[^}]*margin-right/);
     });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const TailwindBootstrapGrid = plugin.withOptions(
                 return classes;
             };
 
-            // generate .offset-{1-12} to add left margin as offset
+            // generate .offset-{1-12} to add inline-start margin as offset
             const generateOffsetClasses = () => {
                 const offsets: CSSRuleObject = {};
 
@@ -76,13 +76,10 @@ const TailwindBootstrapGrid = plugin.withOptions(
                     // calculate in %
                     const percentage = i === 0 ? "0" : `${(i / totalCols) * 100}%`;
 
-                    // .offset-{0-12} => adds left margin to offset the column
+                    // .offset-{0-12} => adds inline-start margin to offset the column,
+                    // so it flips automatically in RTL without a [dir="rtl"] override
                     offsets[`.offset-${i}`] = {
-                        marginLeft: percentage,
-                        '[dir="rtl"] &': {
-                            marginLeft: "0",
-                            marginRight: percentage,
-                        },
+                        marginInlineStart: percentage,
                     };
                 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,7 @@ const TailwindBootstrapGrid = plugin.withOptions(
                     // calculate in %
                     const percentage = i === 0 ? "0" : `${(i / totalCols) * 100}%`;
 
-                    // .offset-{0-12} => adds inline-start margin to offset the column,
-                    // so it flips automatically in RTL without a [dir="rtl"] override
+                    // .offset-{0-12} => adds inline-start margin to offset the column
                     offsets[`.offset-${i}`] = {
                         marginInlineStart: percentage,
                     };


### PR DESCRIPTION
## What changed

`.offset-{0-12}` now emits a single `margin-inline-start` declaration instead of a physical `margin-left` paired with a nested `[dir="rtl"] &` block that zeroed it and set `margin-right`.

```css
/* before */
.offset-1 { margin-left: 8.333333333333332%; }
[dir="rtl"] .offset-1 { margin-left: 0; margin-right: 8.333333333333332%; }

/* after */
.offset-1 { margin-inline-start: 8.333333333333332%; }
```

## Why

The RTL override was a descendant selector, so it only matched when `dir="rtl"` sat on an *ancestor* of the offset element. Two real cases were broken:

- An element carrying its own direction — `<div class="offset-3" dir="rtl">` — never flipped.
- A direction applied from CSS (`direction: rtl`) never flipped at all, since the selector keys off the HTML attribute.

`margin-inline-start` resolves against the element's own computed direction, so both cases work, and the behaviour no longer depends on how direction is expressed. It also removes the `.offset-0` no-op override and shrinks the generated CSS — one declaration per class instead of a declaration plus a nested block.

This makes the offset utilities match the README's claim that directional utilities "adapt automatically to `dir=\"rtl\"`" rather than only doing so under an RTL ancestor.

## Tests

The existing v3 and v4 offset tests were rewritten to assert the logical property. Both suites also gain a case that renders `<div class="offset-3" dir="rtl">` and asserts the rule contains only `margin-inline-start`, with no `[dir="rtl"]` selector and no physical `margin-left`/`margin-right` — locking in the behaviour that motivated the change.

## What a reviewer should check

- **Browser support expectations.** `margin-inline-start` is broadly supported in evergreen browsers but not in IE11 or very old Safari. Confirm that matches the project's stated support floor; this is the behavioural trade-off of the refactor.
- **Downstream override semantics.** Consumers who previously overrode `.offset-*` by writing their own `margin-left` were fighting a physical property; now physical and logical declarations mix, and which wins depends on source order rather than just specificity. Worth a note in the changelog/release notes if that's a plausible usage.
- **Consistency with the rest of the plugin.** `src/index.ts` still uses physical `marginLeft`/`marginRight` for the container and `.row` negative gutters (lines ~128 and ~143). Those are symmetric, so they're direction-agnostic and correct as-is — but confirm you're happy leaving the codebase mixed rather than converting them in the same pass.
- **Demo/safelist.** The demo references offsets (`demo/src/_constants.ts`, `SectionExamples.tsx`, `safelist-tailwind.txt`); class names are unchanged, so nothing should need updating, but a quick RTL spot-check in the demo would confirm the visual result.