### PR TITLE
docs(skills): add installable agent skill for the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ export default {
 
 ---
 
+## 🤖 AI Agent Skill
+
+Using an AI coding agent? Install the official skill so it knows this plugin's
+classes and configuration instead of guessing them:
+
+```bash
+npx skills add bawerbozdag/tw-bootstrap-grid
+```
+
+Works with Claude Code, Cursor, Codex, OpenCode, GitHub Copilot and other
+[supported agents](https://github.com/vercel-labs/skills#supported-agents). Add
+`-g` to install it globally, or `--list` to preview what's included. Once
+installed, the agent picks it up automatically whenever it works on a
+`tw-bootstrap-grid` layout.
+
+👉 Details in [`skills/README.md`](skills/README.md).
+
+---
+
 ## 🧠 Notes
 
 - The plugin **does not override any core Tailwind utility**.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,70 @@
+# Agent Skills
+
+This directory holds the [Agent Skills](https://skills.sh) published by this
+repository. A skill is a `SKILL.md` file (plus optional reference files) that
+teaches an AI coding agent how to use `tw-bootstrap-grid` correctly, instead of
+letting it guess the class names and configuration from memory.
+
+## Available skills
+
+| Skill                                             | Description                                                                                                                                               |
+| :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`tw-bootstrap-grid`](tw-bootstrap-grid/SKILL.md) | Install, configure and build layouts with the plugin: full class reference, Tailwind v3 vs v4 setup, gutter variables, RTL, and the common failure modes. |
+
+## Install
+
+```bash
+npx skills add bawerbozdag/tw-bootstrap-grid
+```
+
+The CLI reads the skills from this directory and installs them into whichever
+agents you select — Claude Code, Cursor, Codex, OpenCode, Gemini CLI, GitHub
+Copilot and others are supported.
+
+Useful variants:
+
+```bash
+# list the skills in this repo without installing anything
+npx skills add bawerbozdag/tw-bootstrap-grid --list
+
+# install globally (~/) instead of into the current project
+npx skills add bawerbozdag/tw-bootstrap-grid -g
+
+# non-interactive, targeting one agent
+npx skills add bawerbozdag/tw-bootstrap-grid -a claude-code -y
+
+# pull the latest version later
+npx skills update tw-bootstrap-grid
+```
+
+Installing project-scoped (the default) puts the skill under your agent's
+directory — `.claude/skills/` for Claude Code, `.cursor/skills/` for Cursor and
+so on — so it can be committed and shared with the team.
+
+Once installed the agent picks the skill up on its own whenever a task involves
+this plugin. No prompt or slash command needed.
+
+## Layout
+
+```
+skills/
+├── README.md
+└── tw-bootstrap-grid/
+    ├── SKILL.md                       # entry point: setup, class table, mental model
+    └── references/
+        ├── setup.md                   # install, plugin options, gutter config, breakpoints
+        ├── classes.md                 # exact generated CSS for every class
+        ├── patterns.md                # layout recipes
+        └── troubleshooting.md         # symptom → cause → fix
+```
+
+`SKILL.md` needs YAML frontmatter with a `name` and a `description`; the
+description is what an agent matches against when deciding whether a task is
+relevant, so it lists the class names and the situations the skill covers.
+
+## Contributing
+
+The skill documents real, verified behaviour of the plugin — the class tables
+and CSS snippets are taken from actual compiled output, not from the docs. When
+you change the plugin's generated CSS, update `references/classes.md` in the
+same PR and re-check the affected claims in `SKILL.md`.

--- a/skills/tw-bootstrap-grid/SKILL.md
+++ b/skills/tw-bootstrap-grid/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: tw-bootstrap-grid
+description: >-
+    Build layouts with the tw-bootstrap-grid Tailwind CSS plugin, which adds a
+    Bootstrap-style 12-column flexbox grid (.container, .row, .col-*, .offset-*,
+    .row-cols-*, .g-*/.gx-*/.gy-* gutters) to Tailwind v3.4.x and v4+. Use when
+    installing or configuring the plugin, writing markup with these classes,
+    tuning gutters, adding RTL layouts, or debugging classes that render with no
+    effect. Covers the v3 vs v4 setup differences and the class collisions with
+    Tailwind's own col-* utilities.
+---
+
+# tw-bootstrap-grid
+
+A Tailwind CSS plugin that adds Bootstrap 5's flexbox grid on top of Tailwind.
+It ships **components only** — it adds no JavaScript and does not remove or
+replace any Tailwind core utility.
+
+Homepage / live docs: <https://tw-bootstrap-grid.vercel.app>
+
+**Do not guess the API.** Everything the plugin generates is listed below or in
+`references/`. If a class is not listed here, the plugin does not generate it —
+reach for a native Tailwind utility instead (`order-*`, `items-*`, `flex-*`, …).
+
+## Setup
+
+Install: `npm install tw-bootstrap-grid` (peer dep: `tailwindcss >= 3.0.0`).
+
+**Tailwind v3** — `tailwind.config.ts`:
+
+```ts
+import Grid from "tw-bootstrap-grid";
+
+export default {
+    content: ["./src/**/*.{html,js,ts,jsx,tsx}"],
+    plugins: [Grid],
+};
+```
+
+**Tailwind v4** — main CSS file:
+
+```css
+@import "tailwindcss";
+@plugin "tw-bootstrap-grid";
+```
+
+The plugin requires a build step (PostCSS, Vite, Webpack, …). It **cannot** be
+used with the Tailwind CDN build.
+
+Detect which version a project is on before writing setup code: Tailwind v4 has
+no `tailwind.config.*` by default and configures itself from CSS (`@import
+"tailwindcss"`), v3 has a config file and `@tailwind base/components/utilities`
+directives. See [setup.md](references/setup.md) for options, gutter
+configuration, and per-version details.
+
+## Class reference
+
+| Class                         | Effect                                                                            |
+| :---------------------------- | :-------------------------------------------------------------------------------- |
+| `.container`                  | `width: 100%`, auto horizontal margins, gutter/2 padding on both sides            |
+| `.container-fluid`            | Same as `.container`, but never gets a `max-width`                                |
+| `.row`                        | `display: flex; flex-wrap: wrap` + negative gutter margins                        |
+| `.row > *`                    | Every direct child: `flex-shrink: 0; width: 100%` + gutter padding and top margin |
+| `.col`                        | `flex: 1 0 0%` — split remaining space evenly                                     |
+| `.col-auto`                   | `flex: 0 0 auto; width: auto` — size to content                                   |
+| `.col-1` … `.col-12`          | `flex: 0 0 auto` + `width: N/12 * 100%`                                           |
+| `.offset-0` … `.offset-12`    | `margin-inline-start: N/12 * 100%`                                                |
+| `.row-cols-1` … `.row-cols-6` | On a `.row`: force every child to `100/N %` width                                 |
+| `.row-cols-auto`              | On a `.row`: every child sizes to its content                                     |
+| `.g-<n>`                      | Sets both `--bs-gutter-x` and `--bs-gutter-y`                                     |
+| `.gx-<n>`                     | Sets `--bs-gutter-x` (horizontal) only                                            |
+| `.gy-<n>`                     | Sets `--bs-gutter-y` (vertical) only                                              |
+
+All of them accept Tailwind responsive variants: `md:col-6`, `lg:offset-3`,
+`sm:row-cols-2`, `xl:gy-8`.
+
+Exact generated CSS for every class: [classes.md](references/classes.md).
+
+## Mental model
+
+1. **`.row` styles its children, not just itself.** The gutter padding, the
+   `width: 100%` default and the `margin-top` live in a `.row > *` rule. A
+   column only behaves like a column when it is a **direct child** of a `.row`.
+   Wrapping columns in an extra `<div>` breaks the layout.
+
+2. **Columns default to full width.** `.row > *` sets `width: 100%`, so a child
+   with no `.col-*` class becomes a full-width row of its own. This is what
+   makes mobile-first markup work: `class="col-12 md:col-6"` is really just
+   `class="md:col-6"` plus the default.
+
+3. **Gutters are CSS variables, not fixed values.** `.row` and `.container`
+   declare `--bs-gutter-x` / `--bs-gutter-y`; the padding and margin rules read
+   them. `.g-*` / `.gx-*` / `.gy-*` only reassign those variables, which is why
+   they must be placed **on the `.row`** (or on `.container`), never on a
+   column.
+
+    ```html
+    <!-- correct -->
+    <div class="row gy-4"><div class="col-6">…</div></div>
+    <!-- wrong: sets the variable on an element that never reads it -->
+    <div class="row"><div class="col-6 gy-4">…</div></div>
+    ```
+
+4. **Vertical gutters are 0 by default.** `--bs-gutter-y` defaults to `0`, so
+   wrapped rows touch each other. Add `gy-*` (or `g-*`) whenever a row can wrap.
+
+5. **The 12-column math is percentage widths on flex items** — not CSS Grid.
+   Total per row must stay at or under 12 or the columns wrap.
+
+## Common patterns
+
+Responsive cards, mobile-first, with vertical gutter for the wrap:
+
+```html
+<div class="container">
+    <div class="row gy-4">
+        <div class="col-12 sm:col-6 lg:col-4">Card 1</div>
+        <div class="col-12 sm:col-6 lg:col-4">Card 2</div>
+        <div class="col-12 sm:col-6 lg:col-4">Card 3</div>
+    </div>
+</div>
+```
+
+Centering a column — offset half of the remaining columns:
+
+```html
+<div class="row">
+    <div class="col-6 offset-3">Centered</div>
+</div>
+```
+
+Equal-width columns without counting (`row-cols-*` sets the children's width):
+
+```html
+<div class="row row-cols-2 lg:row-cols-3 g-4">
+    <div class="col">1</div>
+    <div class="col">2</div>
+    <div class="col">3</div>
+</div>
+```
+
+Reordering uses **Tailwind's own** `order-*` utilities — the plugin has no
+order classes:
+
+```html
+<div class="row">
+    <div class="col-6 order-2 md:order-1">Left on desktop</div>
+    <div class="col-6 order-1 md:order-2">Right on desktop</div>
+</div>
+```
+
+More recipes (nested rows, sidebar layouts, RTL, full-bleed sections):
+[patterns.md](references/patterns.md).
+
+## RTL
+
+Set `dir="rtl"` and the grid flips on its own — no config, no variant, no
+separate stylesheet:
+
+```html
+<div class="container" dir="rtl">
+    <div class="row">
+        <div class="col-4 offset-2">…</div>
+    </div>
+</div>
+```
+
+`.offset-*` uses the logical `margin-inline-start`, so it follows the element's
+own resolved direction. Flex ordering follows `dir` natively. Do **not** add
+`[dir="rtl"]` overrides or `rtl:` variants for offsets — they would double-flip.
+
+## Gotchas
+
+- **Gutter classes only exist for whole-number spacing keys.** The plugin skips
+  every spacing key containing a `.`, so `g-0.5`, `gx-1.5`, `gy-2.5` and
+  `g-3.5` **do not exist**. Valid keys: `px`, `0`–`12`, `14`, `16`, `20`, `24`,
+  `28`, `32`, `36`, `40`, `44`, `48`, `52`, `56`, `60`, `64`, `72`, `80`, `96`.
+  Arbitrary values (`g-[10px]`) are not supported either — set
+  `--bs-gutter-x` inline or via a theme variable instead.
+- **On Tailwind v4, `g-13`-style keys do not work** even though `p-13` does.
+  The plugin reads the v3-compat `theme("spacing")` map, not v4's dynamic
+  `--spacing` multiplier scale.
+- **`col-*` collides with Tailwind's own `col-*` (`grid-column`).** On v4,
+  `col-6` is also a core utility (`grid-column: 6`); on v3 only `col-auto` is.
+  Both rules get emitted for the same class name — the plugin supplies
+  `flex`/`width`, the core utility's `grid-column` survives alongside it.
+  Harmless inside a `.row` (a flex container ignores `grid-column`), but on v4
+  a `.col-6` inside a CSS Grid container will silently land in grid column 6.
+  Use `col-span-6` for real CSS Grid, `col-6` for this plugin's grid.
+- **`.container`'s responsive `max-width` comes from Tailwind, not this
+  plugin.** The plugin only adds the gutter padding and `margin: auto`. Change
+  the widths by editing your breakpoints (v3 `theme.screens`, v4
+  `--breakpoint-*`), and note `.container-fluid` gets no `max-width` at all.
+- **Dynamically built class names get purged.** `` `col-${n}` `` is invisible to
+  Tailwind's scanner. Write the full class name out, or safelist it (v3
+  `safelist`, v4 `@source inline(...)`).
+
+Full list with symptoms and fixes: [troubleshooting.md](references/troubleshooting.md).

--- a/skills/tw-bootstrap-grid/references/classes.md
+++ b/skills/tw-bootstrap-grid/references/classes.md
@@ -1,0 +1,178 @@
+# Generated CSS reference
+
+Exactly what the plugin emits. Anything not on this page is not generated.
+
+## Container
+
+Emitted unless `generateContainers: false`. `.container` and `.container-fluid`
+share one rule:
+
+```css
+.container,
+.container-fluid {
+    --bs-gutter-x: var(--bs-container-gutter-x, var(--bs-global-gutter-x, 1.5rem));
+    --bs-gutter-y: var(--bs-container-gutter-y, var(--bs-global-gutter-y, 0));
+    width: 100%;
+    padding-right: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+    padding-left: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+    margin-right: auto;
+    margin-left: auto;
+}
+```
+
+The responsive `max-width` steps you see on `.container` come from **Tailwind
+itself** (v3's core container plugin, v4's `container` utility), not from here.
+That is why `.container` is capped at each breakpoint and `.container-fluid`
+never is.
+
+## Row
+
+```css
+.row {
+    --bs-gutter-x: var(--bs-row-gutter-x, var(--bs-global-gutter-x, 1.5rem));
+    --bs-gutter-y: var(--bs-row-gutter-y, var(--bs-global-gutter-y, 0));
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: calc(-1 * var(--bs-gutter-y, 0));
+    margin-right: calc(-0.5 * var(--bs-gutter-x, 1.5rem));
+    margin-left: calc(-0.5 * var(--bs-gutter-x, 1.5rem));
+}
+
+.row > * {
+    flex-shrink: 0;
+    width: 100%;
+    padding-right: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+    padding-left: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+    margin-top: var(--bs-gutter-y, 0);
+}
+```
+
+The negative margins on `.row` cancel the padding the children add, so a row
+still lines up flush with its container's edges. This is why a `.row` should
+normally sit inside a `.container` (or another padded element) — dropping one
+straight into `<body>` makes the first and last columns bleed by half a gutter.
+
+## Columns
+
+```css
+.col {
+    flex: 1 0 0%;
+}
+.col-auto {
+    flex: 0 0 auto;
+    width: auto;
+}
+```
+
+`.col-1` … `.col-12` — `flex: 0 0 auto` plus `width: N/12 * 100%`:
+
+| Class    | width                 | Class     | width                 |
+| :------- | :-------------------- | :-------- | :-------------------- |
+| `.col-1` | `8.333333333333332%`  | `.col-7`  | `58.333333333333336%` |
+| `.col-2` | `16.666666666666664%` | `.col-8`  | `66.66666666666666%`  |
+| `.col-3` | `25%`                 | `.col-9`  | `75%`                 |
+| `.col-4` | `33.33333333333333%`  | `.col-10` | `83.33333333333334%`  |
+| `.col-5` | `41.66666666666667%`  | `.col-11` | `91.66666666666666%`  |
+| `.col-6` | `50%`                 | `.col-12` | `100%`                |
+
+## Offsets
+
+`.offset-0` … `.offset-12`, one logical property each:
+
+```css
+.offset-0 {
+    margin-inline-start: 0;
+}
+.offset-3 {
+    margin-inline-start: 25%;
+}
+.offset-12 {
+    margin-inline-start: 100%;
+}
+```
+
+`margin-inline-start` resolves against the element's own direction, so offsets
+flip under `dir="rtl"` with no extra selector. The generated CSS contains **no**
+`[dir="rtl"]` rules and no physical `margin-left` / `margin-right`.
+
+## Row columns
+
+Applied to the `.row`, styling `> .col` and `> *`:
+
+```css
+.row-cols-auto > .col,
+.row-cols-auto > * {
+    flex: 0 0 auto;
+    width: auto;
+}
+.row-cols-1 > .col,
+.row-cols-1 > * {
+    flex: 0 0 auto;
+    width: 100%;
+}
+```
+
+| Class            | child width           |
+| :--------------- | :-------------------- |
+| `.row-cols-1`    | `100%`                |
+| `.row-cols-2`    | `50%`                 |
+| `.row-cols-3`    | `33.33333333333333%`  |
+| `.row-cols-4`    | `25%`                 |
+| `.row-cols-5`    | `20%`                 |
+| `.row-cols-6`    | `16.666666666666664%` |
+| `.row-cols-auto` | `auto`                |
+
+Only 1–6 exist. `row-cols-*` targets **direct children**, so a nested `.row`
+inside a `row-cols-3` parent gets its width set too.
+
+## Gutters
+
+Built from Tailwind's `theme("spacing")`, **skipping every key that contains a
+dot**. Generated keys:
+
+```
+px  0  1  2  3  4  5  6  7  8  9  10  11  12  14  16  20  24  28  32  36
+40  44  48  52  56  60  64  72  80  96
+```
+
+Not generated: `0.5`, `1.5`, `2.5`, `3.5` (fractional keys), and — on Tailwind
+v4 — any key outside the list above, because the plugin reads the v3-compat
+spacing map rather than v4's dynamic `--spacing` scale. `g-13` does not exist
+even though `p-13` does.
+
+```css
+.g-4 {
+    --bs-gutter-x: 1rem;
+    --bs-gutter-y: 1rem;
+}
+.gx-4 {
+    --bs-gutter-x: 1rem;
+}
+.gy-4 {
+    --bs-gutter-y: 1rem;
+}
+```
+
+They set variables only. Put them on the element that reads them — `.row` or
+`.container` — and remember `.row` re-declares both variables, so a `g-*` on an
+ancestor is overwritten by any `.row` below it.
+
+## Gutter variable chain
+
+| Variable                          | Set by                                         | Read by                    |
+| :-------------------------------- | :--------------------------------------------- | :------------------------- |
+| `--bs-gutter-x` / `--bs-gutter-y` | `.container`, `.row`, `.g-*`, `.gx-*`, `.gy-*` | the padding / margin rules |
+| `--bs-container-gutter-x` / `-y`  | you (theme or inline)                          | `.container` default       |
+| `--bs-row-gutter-x` / `-y`        | you (theme or inline)                          | `.row` default             |
+| `--bs-global-gutter-x` / `-y`     | you (theme or inline)                          | fallback for both          |
+
+Precedence, highest first: a `.g-*` class on the element → the scope-specific
+variable (`--bs-row-gutter-x`) → the global variable
+(`--bs-global-gutter-x`) → the build-time option → `1.5rem` / `0`.
+
+## Not generated by this plugin
+
+`order-*`, `col-span-*`, `justify-*`, `items-*`, `flex-*`, `gap-*`,
+`.col-{breakpoint}-{n}` (Bootstrap's own syntax — use Tailwind's `md:col-6`
+instead), and `.g-*` with arbitrary values. Use native Tailwind utilities for
+all of these.

--- a/skills/tw-bootstrap-grid/references/patterns.md
+++ b/skills/tw-bootstrap-grid/references/patterns.md
@@ -1,0 +1,195 @@
+# Layout patterns
+
+All examples assume the plugin is installed and the markup sits inside a
+`.container` or `.container-fluid`.
+
+## Mobile-first card grid
+
+Start full width, narrow as the viewport grows. `gy-*` is what keeps the rows
+from touching once they wrap.
+
+```html
+<div class="container">
+    <div class="row gy-4">
+        <div class="col-12 sm:col-6 lg:col-4">Card 1</div>
+        <div class="col-12 sm:col-6 lg:col-4">Card 2</div>
+        <div class="col-12 sm:col-6 lg:col-4">Card 3</div>
+    </div>
+</div>
+```
+
+`col-12` is technically redundant — `.row > *` already defaults to `width: 100%`
+— but writing it keeps the intent readable and survives refactors.
+
+## Uniform grid without counting columns
+
+`row-cols-*` sets the width from the parent, so adding or removing children
+needs no edits:
+
+```html
+<div class="row row-cols-2 md:row-cols-3 xl:row-cols-4 g-4">
+    <div class="col">1</div>
+    <div class="col">2</div>
+    <div class="col">3</div>
+    <div class="col">4</div>
+    <div class="col">5</div>
+</div>
+```
+
+Use this for rendered lists (`items.map(...)`) — it avoids computing a class
+name per item, which the Tailwind scanner cannot see anyway.
+
+## Sidebar + main
+
+```html
+<div class="row gx-6 gy-4">
+    <aside class="col-12 lg:col-3">Sidebar</aside>
+    <main class="col-12 lg:col-9">Content</main>
+</div>
+```
+
+Sidebar last in the DOM but first on desktop — use Tailwind's `order-*`:
+
+```html
+<div class="row gx-6 gy-4">
+    <main class="col-12 lg:col-9 order-1 lg:order-2">Content</main>
+    <aside class="col-12 lg:col-3 order-2 lg:order-1">Sidebar</aside>
+</div>
+```
+
+## Centering with offsets
+
+An offset of `(12 - n) / 2` centers an `n`-wide column:
+
+```html
+<div class="row">
+    <div class="col-8 offset-2">8 wide, centered</div>
+</div>
+
+<!-- narrows as the viewport grows -->
+<div class="row">
+    <div class="col-12 sm:col-8 sm:offset-2 lg:col-6 lg:offset-3">Responsive centered column</div>
+</div>
+```
+
+Reset an offset at a larger breakpoint with `offset-0`:
+
+```html
+<div class="col-10 offset-1 md:col-12 md:offset-0">…</div>
+```
+
+## Pushing a column to the right
+
+Offset the gap instead of adding a spacer element:
+
+```html
+<div class="row">
+    <div class="col-4">Left</div>
+    <div class="col-4 offset-4">Right</div>
+</div>
+```
+
+## Nested rows
+
+A nested `.row` works because its negative margins cancel the parent column's
+gutter padding. The inner row is its own 12-column context:
+
+```html
+<div class="row">
+    <div class="col-12 md:col-8">
+        <div class="row gy-3">
+            <div class="col-6">Nested A</div>
+            <div class="col-6">Nested B</div>
+        </div>
+    </div>
+    <div class="col-12 md:col-4">Aside</div>
+</div>
+```
+
+Note that `row-cols-*` on the outer row also hits the nested `.row` (it matches
+`> *`). Keep nested rows out of `row-cols-*` parents, or re-set the width on the
+wrapper.
+
+## Auto-sizing columns
+
+`.col` splits whatever is left; `.col-auto` takes only what it needs:
+
+```html
+<div class="row">
+    <div class="col-auto">Label</div>
+    <div class="col">Fills the rest</div>
+    <div class="col-auto">Action</div>
+</div>
+```
+
+Several `.col`s in one row share the free space equally.
+
+## Removing gutters
+
+```html
+<!-- edge-to-edge tiles -->
+<div class="row g-0">
+    <div class="col-6">A</div>
+    <div class="col-6">B</div>
+</div>
+
+<!-- horizontal gutters only, no vertical -->
+<div class="row gx-4 gy-0">…</div>
+```
+
+## Full-bleed section with contained content
+
+```html
+<section class="container-fluid g-0">
+    <div class="container">
+        <div class="row gy-5">…</div>
+    </div>
+</section>
+```
+
+## RTL
+
+No configuration and no `rtl:` variants — set `dir` and everything mirrors:
+
+```html
+<div class="container" dir="rtl">
+    <div class="row gy-4">
+        <div class="col-4">١</div>
+        <div class="col-4 offset-4">٢</div>
+    </div>
+</div>
+```
+
+`offset-4` becomes a right-hand offset because it compiles to
+`margin-inline-start`. Flex order follows `dir` too, so `order-*` keeps working.
+Adding `[dir="rtl"]` overrides or `rtl:offset-*` would flip the offset a second
+time and put it back on the wrong side.
+
+## Rendering lists safely
+
+Tailwind only sees class names that appear literally in your source. This is
+broken:
+
+```jsx
+<div className={`col-${span}`}>…</div> // never generated
+```
+
+Pick one of:
+
+```jsx
+// 1. row-cols-* on the parent — nothing per item to generate
+<div className="row row-cols-2 md:row-cols-4">
+    {items.map((i) => (
+        <div key={i.id} className="col">
+            {i.name}
+        </div>
+    ))}
+</div>;
+
+// 2. a literal lookup map
+const SPAN = { 4: "col-4", 6: "col-6", 12: "col-12" };
+<div className={SPAN[span]}>…</div>;
+```
+
+If you truly need dynamic names, safelist them: Tailwind v3 `safelist` in the
+config, Tailwind v4 `@source inline("col-{1,2,3,4,6,12}")`.

--- a/skills/tw-bootstrap-grid/references/setup.md
+++ b/skills/tw-bootstrap-grid/references/setup.md
@@ -1,0 +1,172 @@
+# Setup and configuration
+
+## Install
+
+```bash
+npm install tw-bootstrap-grid
+# or: yarn add tw-bootstrap-grid / pnpm add tw-bootstrap-grid
+```
+
+Peer dependency: `tailwindcss >= 3.0.0`. Tested against **v3.4.x** and **v4+**.
+Node `>= 18`.
+
+The plugin runs at build time and needs a real build pipeline (PostCSS, Vite,
+Webpack, Next.js, …). It does **not** work with the Tailwind CDN script.
+
+## Tailwind v3
+
+```ts
+// tailwind.config.ts
+import Grid from "tw-bootstrap-grid";
+
+export default {
+    content: ["./src/**/*.{html,js,ts,jsx,tsx}"],
+    plugins: [Grid],
+};
+```
+
+Pass options by calling the plugin:
+
+```ts
+import Grid from "tw-bootstrap-grid";
+
+export default {
+    content: ["./src/**/*.{html,js,ts,jsx,tsx}"],
+    plugins: [
+        Grid({
+            gutters: { x: "1.5rem", y: "0" }, // global fallback
+            containerGutters: { x: "2rem", y: "0" }, // .container / .container-fluid
+            rowGutters: { x: "1.5rem", y: "1rem" }, // .row
+            generateContainers: true,
+        }),
+    ],
+};
+```
+
+| Option               | Type                         | Default                   | Effect                                                             |
+| :------------------- | :--------------------------- | :------------------------ | :----------------------------------------------------------------- |
+| `gutters`            | `{ x?: string; y?: string }` | `{ x: "1.5rem", y: "0" }` | Fallback for both container and row                                |
+| `containerGutters`   | `{ x?: string; y?: string }` | inherits `gutters`        | `.container` / `.container-fluid` only                             |
+| `rowGutters`         | `{ x?: string; y?: string }` | inherits `gutters`        | `.row` only                                                        |
+| `generateContainers` | `boolean`                    | `true`                    | `false` skips the `.container` / `.container-fluid` rules entirely |
+
+Resolution order per axis: **specific → global → built-in default**. The
+resolved value is only the _last_ fallback in the emitted CSS variable chain:
+
+```css
+.row {
+    --bs-gutter-x: var(--bs-row-gutter-x, var(--bs-global-gutter-x, 1.5rem));
+}
+```
+
+So a runtime `--bs-row-gutter-x` or `--bs-global-gutter-x` still wins over
+whatever you configured at build time.
+
+## Tailwind v4
+
+```css
+@import "tailwindcss";
+@plugin "tw-bootstrap-grid";
+```
+
+`@plugin` option blocks only accept **flat** key/value pairs, so the nested
+`gutters` / `containerGutters` / `rowGutters` objects are v3-only. The boolean
+option works:
+
+<!-- prettier-ignore -->
+```css
+@import "tailwindcss";
+@plugin "tw-bootstrap-grid" {
+    generateContainers: false;
+}
+```
+
+Configure gutters in v4 by defining the CSS variables the plugin already falls
+back to — this is the documented v4 path and it is equivalent to the v3 options:
+
+```css
+@import "tailwindcss";
+@plugin "tw-bootstrap-grid";
+
+@theme {
+    /* global fallback for container + row */
+    --bs-global-gutter-x: 1.5rem;
+    --bs-global-gutter-y: 0;
+
+    /* per-scope overrides (optional) */
+    --bs-container-gutter-x: 2rem;
+    --bs-container-gutter-y: 0;
+    --bs-row-gutter-x: 1.5rem;
+    --bs-row-gutter-y: 1rem;
+}
+```
+
+Custom-namespace variables like these are always emitted by v4 — they are not
+tree-shaken the way unused `--color-*` / `--spacing-*` theme values are.
+
+Because they are plain CSS variables, you can also scope them without touching
+the build:
+
+```html
+<section style="--bs-row-gutter-y: 2rem">
+    <div class="row">…</div>
+</section>
+```
+
+## Breakpoints
+
+The plugin generates no breakpoints of its own — responsive variants
+(`md:col-6`) and `.container`'s `max-width` steps both come from Tailwind. To
+change them, change Tailwind's breakpoints.
+
+**v3:**
+
+```ts
+export default {
+    theme: {
+        screens: {
+            sm: "40rem", // 640px
+            md: "48rem", // 768px
+            lg: "64rem", // 1024px
+            xl: "80rem", // 1280px
+            "2xl": "96rem", // 1536px
+        },
+    },
+    plugins: [Grid],
+};
+```
+
+**v4:**
+
+```css
+@theme {
+    --breakpoint-sm: 40rem;
+    --breakpoint-md: 48rem;
+    --breakpoint-lg: 64rem;
+    --breakpoint-xl: 80rem;
+    --breakpoint-2xl: 96rem;
+}
+```
+
+## Where the classes land in the cascade
+
+The plugin uses `addComponents`, but the two Tailwind versions place the output
+differently:
+
+- **v3** — components layer, i.e. _before_ utilities. Tailwind utilities beat
+  the plugin: `class="col-6 w-1/3"` renders at one third.
+- **v4** — the rules end up inside `@layer utilities`, after Tailwind's own
+  utilities of the same name. For a class that exists in both (`col-6`,
+  `col-auto`) the plugin's declarations win on the properties it sets; the core
+  utility's other properties (`grid-column`) still apply.
+
+Either way, use `!` (`w-1/3!` in v4, `!w-1/3` in v3) when you need a utility to
+beat the grid unconditionally.
+
+## Turning containers off
+
+Set `generateContainers: false` when you already have your own `.container` (a
+common clash in projects migrating from Bootstrap, or when Tailwind's own
+`container` utility with `center`/`padding` config is enough). The plugin then
+emits no `.container` and no `.container-fluid` — `.row`, `.col-*`, offsets,
+gutters and `row-cols-*` are unaffected.

--- a/skills/tw-bootstrap-grid/references/troubleshooting.md
+++ b/skills/tw-bootstrap-grid/references/troubleshooting.md
@@ -1,0 +1,159 @@
+# Troubleshooting
+
+Symptom-first. Each entry names the cause and the fix.
+
+## Nothing happens — no grid CSS at all
+
+- **Tailwind CDN.** The plugin is a build-time plugin and the CDN build cannot
+  load it. Move to PostCSS / Vite / Webpack / Next.js.
+- **Plugin not registered.** v3 needs `plugins: [Grid]` in `tailwind.config.*`;
+  v4 needs `@plugin "tw-bootstrap-grid";` in the CSS file that also has
+  `@import "tailwindcss";`.
+- **File not scanned.** v3: the file must match a `content` glob. v4: it must be
+  under a scanned source root (`@source` if it is outside the CSS file's
+  project directory).
+
+Quick check: search the compiled CSS for `--bs-gutter-x`. If it is missing, the
+plugin never ran.
+
+## A specific class does nothing, others work
+
+Almost always the scanner. ``className={`col-${n}`}``, `"col-" + n`, or class
+names assembled in a config/CMS string are invisible to Tailwind. Write literal
+class names, use a lookup map, or safelist:
+
+```ts
+// v3
+safelist: ["col-4", "col-6", "col-8", { pattern: /^(col|offset)-(\d{1,2})$/ }];
+```
+
+```css
+/* v4 */
+@source inline("{col,offset}-{1,2,3,4,6,8,12}");
+```
+
+## `g-0.5`, `gx-1.5`, `g-2.5` are not generated
+
+By design — the plugin skips every spacing key containing a dot. Whole-number
+keys and `px` only. For a half-step gutter set the variable directly:
+
+```html
+<div class="row" style="--bs-gutter-x: 0.125rem">…</div>
+```
+
+or define `--bs-row-gutter-x` in your theme.
+
+## `g-13` (or any custom spacing key) is not generated on Tailwind v4
+
+The plugin builds gutters from `theme("spacing")`, which on v4 resolves to the
+v3-compat spacing map rather than v4's dynamic `--spacing` multiplier. Extending
+`--spacing` in `@theme` does not add gutter classes. Use `--bs-*-gutter-*`
+variables instead.
+
+## `g-*` on a column has no effect
+
+Gutter classes only assign CSS variables. Only `.container` and `.row` read
+them. Put the class on the `.row`:
+
+```html
+<div class="row gy-4">
+    <div class="col-6">…</div>
+</div>
+```
+
+## A `g-*` on `.container` gets ignored inside a `.row`
+
+`.row` re-declares both `--bs-gutter-x` and `--bs-gutter-y` on itself, which
+shadows the value inherited from the container. Put the gutter class on each
+`.row`, or set `--bs-row-gutter-*` / `--bs-global-gutter-*` so the row's own
+default already resolves to what you want.
+
+## Rows are glued together vertically
+
+`--bs-gutter-y` defaults to `0`. Add `gy-*` (or `g-*`, which sets both axes) to
+any row that can wrap.
+
+## Columns are wider than the row / everything wraps early
+
+- The `col-*` values in one row add up to more than 12.
+- A column is not a **direct child** of the `.row`. An intermediate wrapper
+  `<div>` swallows the `.row > *` rule; the wrapper becomes the flex item and
+  the column inside it is 100% wide. Remove the wrapper or move the `col-*`
+  class onto it.
+
+## Content bleeds half a gutter past the edge of the screen
+
+`.row` carries negative horizontal margins that expect the parent to supply the
+matching padding. Wrap it in `.container` / `.container-fluid`, or add your own
+horizontal padding to the parent, or use `g-0` to zero the gutters out.
+
+## `col-6` inside a CSS Grid container jumps to column 6
+
+Tailwind v4's own `col-<number>` utility maps to `grid-column`. Both rules are
+emitted for the same class name; the plugin supplies `flex` and `width`, but
+`grid-column: 6` survives and takes effect inside a real grid container. Use
+`col-span-6` for CSS Grid and reserve `col-6` for `.row`.
+
+On Tailwind v3 only `col-auto` overlaps (`grid-column: auto`), and there the
+core utility is emitted after the plugin's component, so `grid-column` wins on
+that property while `flex: 0 0 auto; width: auto` still applies. Inside a flex
+`.row` the result is identical either way.
+
+## A Tailwind utility does not override a grid class
+
+- **v3** — utilities come after the plugin's components, so `w-1/3` already
+  wins over `col-6`. If it still does not, check for a `!important` elsewhere,
+  or use `!w-1/3`.
+- **v4** — both live in `@layer utilities`, and Tailwind sorts core utilities
+  after the plugin's, so `w-1/3` wins there too. Use `w-1/3!` to force it.
+
+## `.container` is the wrong width
+
+The `max-width` steps come from Tailwind's own container, not from this plugin —
+change your breakpoints (v3 `theme.screens`, v4 `--breakpoint-*`). Only the
+horizontal padding and `margin: auto` come from the plugin, and those are tuned
+with the container gutter (`containerGutters` in v3, `--bs-container-gutter-x`
+in v4).
+
+Note `.container-fluid` never receives a `max-width` — that is intentional.
+
+## `.container` conflicts with an existing container style
+
+Disable the plugin's version and keep your own:
+
+```ts
+Grid({ generateContainers: false }); // v3
+```
+
+<!-- prettier-ignore -->
+```css
+/* v4 */
+@plugin "tw-bootstrap-grid" {
+    generateContainers: false;
+}
+```
+
+`.row`, `.col-*`, `.offset-*`, `.row-cols-*` and the gutter classes are
+unaffected.
+
+## RTL offsets land on the wrong side
+
+The offset is being flipped twice. `.offset-*` compiles to
+`margin-inline-start`, which already follows `dir`. Delete any `[dir="rtl"]`
+override, `rtl:` variant, or `margin-left`/`margin-right` patch you added for
+offsets, and make sure `dir="rtl"` is set on the element or an ancestor rather
+than emulated in CSS.
+
+## `row-cols-*` is overriding a nested row's width
+
+`row-cols-*` targets `> *`, which includes a nested `.row`. Either avoid nesting
+directly inside a `row-cols-*` parent, or wrap the nested row in a `.col-12`
+child so only the wrapper is resized.
+
+## `import Grid from "tw-bootstrap-grid"` throws in a pure ESM script
+
+Loading the ESM build directly from Node with Tailwind v3 installed fails with
+`Dynamic require of "tailwindcss/plugin" is not supported`. Normal setups are
+unaffected because Tailwind loads `tailwind.config.*` through its own
+CJS-capable loader. If you hit it in a standalone script, require the CJS
+build (`require("tw-bootstrap-grid")`) instead.


### PR DESCRIPTION
## What
Adds an Agent Skills package under `skills/` so AI coding agents (Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, etc.) can be taught this plugin's real API instead of guessing class names from training data, plus a README section pointing users at it.

- `skills/tw-bootstrap-grid/SKILL.md` — entry point with YAML frontmatter (`name`, `description` used for agent task-matching), setup for Tailwind v3 vs v4, the full class reference table, the plugin's mental model (row/column relationship, gutter CSS variables, RTL), common layout patterns, and a gotchas section (purged dynamic classes, `col-*` collision with Tailwind's core grid utility, v4 spacing-key limits).
- `skills/tw-bootstrap-grid/references/` — four supporting docs linked from `SKILL.md`: `setup.md` (install/config/gutters per Tailwind version), `classes.md` (exact generated CSS per class), `patterns.md` (layout recipes), `troubleshooting.md` (symptom → cause → fix).
- `skills/README.md` — explains what the skill directory is, how to install it (`npx skills add bawerbozdag/tw-bootstrap-grid`, with `-g`/`--list`/`-a`/`update` variants), the file layout, and a contributing note to keep `classes.md` in sync with the plugin's actual compiled CSS output.
- `README.md` — new "🤖 AI Agent Skill" section advertising the install command and linking to `skills/README.md`.

## Why
Agents otherwise hallucinate Bootstrap-style class names or Tailwind config options that don't match what this plugin actually generates (e.g. confusing `col-*` with Tailwind's own grid `col-*` utility, or assuming fractional gutter keys like `g-0.5` exist). Publishing a skill lets agents pull verified, plugin-specific behavior on demand instead of guessing.

## Notes for reviewers
- Documentation-only change — no source, build, or published-package files are touched.
- Worth spot-checking that the class reference in `SKILL.md`/`references/classes.md` and the RTL claims (`margin-inline-start`, no `[dir="rtl"]` override needed) match current plugin behavior, since `d87912b`/`879d7e7` recently changed the offset implementation to logical properties.
- The `npx skills add bawerbozdag/tw-bootstrap-grid` install command and the `skills.sh`/`vercel-labs/skills` links assume this repo is published there under that org/repo name — confirm that's correct before merging.